### PR TITLE
Fix: Add proper export maps for better import resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,24 @@
   "version": "1.1.3",
   "type": "module",
   "description": "Type-safe data mapper for TypeScript with zero runtime overhead",
-  "main": "index.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "npm run clean && npm run build:types && npm run build:cjs && npm run build:esm",
     "build:types": "tsc --project tsconfig.build.json --emitDeclarationOnly --outDir dist/types",


### PR DESCRIPTION
Problem
Currently, importing the package using import { createMapper, h } from '@mahmoudxyz/hassan' fails because:

The main field points to index.js, which doesn't exist in the root
Missing proper export maps for the built files in dist/
No module or types fields defined

Solution

✅ Updated main field to point to ./dist/cjs/index.js
✅ Added module field pointing to ./dist/esm/index.js
✅ Added types field pointing to ./dist/types/index.d.ts
✅ Added proper exports map supporting both import and require
✅ Added files field to only publish the dist folder

Testing
After this change, users can import the package normally:
typescriptimport { createMapper, h } from '@mahmoudxyz/hassan'
Instead of having to use the full path:
typescriptimport { createMapper, h } from '@mahmoudxyz/hassan/dist/esm/index.js'
Backward Compatibility
This change is fully backward compatible and follows modern Node.js package standards.